### PR TITLE
fix: cicd; types_max_hash_size

### DIFF
--- a/.platform/nginx/conf.d/10-types-hash.conf
+++ b/.platform/nginx/conf.d/10-types-hash.conf
@@ -1,0 +1,1 @@
+types_hash_max_size 4096;


### PR DESCRIPTION
## 🛠️ 변경 사항
- adjust nginx conf; types_hash_max_size=4096

## ⚡️ Issue number & Link
- #32 
