### PR TITLE
fix: cicd; types_hash_max_size 4096 -> 1024

### DIFF
--- a/.platform/nginx/conf.d/10-types-hash.conf
+++ b/.platform/nginx/conf.d/10-types-hash.conf
@@ -1,1 +1,1 @@
-types_hash_max_size 4096;
+types_hash_max_size 1024;


### PR DESCRIPTION

## 🛠️ 변경 사항
- types_hash_max_size 4096 -> 1024

## ⚡️ Issue number & Link
- #32 