### PR TITLE
fix: cicd; types_hash_max_size 1024 -> 2048

### DIFF
--- a/.platform/nginx/conf.d/10-types-hash.conf
+++ b/.platform/nginx/conf.d/10-types-hash.conf
@@ -1,1 +1,1 @@
-types_hash_max_size 1024;
+types_hash_max_size 2048;


### PR DESCRIPTION

## 🛠️ 변경 사항
- types_hash_max_size 1024 -> 2048


## ⚡️ Issue number & Link
- #32 
- 
