### PR TITLE
Fix: GlobalExceptionHanlder, CustomException 수정

### DIFF
--- a/src/main/java/com/pintogether/backend/exception/CustomException.java
+++ b/src/main/java/com/pintogether/backend/exception/CustomException.java
@@ -1,31 +1,23 @@
 package com.pintogether.backend.exception;
 
-import com.pintogether.backend.model.ErrorCode;
+import com.pintogether.backend.model.StatusCode;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
-
-import java.util.AbstractMap;
-import java.util.Map;
-
 public class CustomException extends RuntimeException {
     @Getter
-    private final ErrorCode errorCode;
+    private final StatusCode statusCode;
     private String message;
-    @Getter
-    private Map.Entry<String, Object> data;
 
     // 생성자
-    public CustomException(ErrorCode errorCode, String message, Object data) {
-        this.errorCode = errorCode;
+    public CustomException(StatusCode statusCode, String message) {
+        this.statusCode = statusCode;
         this.message = message;
-        this.data = new AbstractMap.SimpleEntry<>(data.getClass().getSimpleName(), data);
     }
 
     public String getMessage() {
         if(StringUtils.hasLength(this.message)) {
             return this.message;
         }
-        return errorCode.getMessage();
+        return statusCode.getMessage();
     }
-
 }

--- a/src/main/java/com/pintogether/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pintogether/backend/exception/GlobalExceptionHandler.java
@@ -1,36 +1,30 @@
 package com.pintogether.backend.exception;
-import com.pintogether.backend.model.ErrorCode;
+import com.pintogether.backend.model.ApiResponse;
+import com.pintogether.backend.model.StatusCode;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
-import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseBody
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseEntity<Map<String, Object>> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        // 검증 실패한 필드와 메시지를 추출
+    public ApiResponse handleValidationExceptions(MethodArgumentNotValidException ex) {
         String errorMessage = ex.getBindingResult().getAllErrors().stream()
                 .map(error -> error.getDefaultMessage())
                 .findFirst()
                 .orElse("Invalid input data");
+        return new ApiResponse(StatusCode.BAD_REQUEST.getCode(), errorMessage, ex.getBindingResult().getTarget());
+    }
 
-        // 응답할 JSON 구조를 생성
-        Map<String, Object> response = new HashMap<>();
-        response.put("errorCode", ErrorCode.BAD_REQUEST.getCode());
-        response.put("message", errorMessage);
-        // 입력된 데이터를 포함. 실제 프로젝트에 따라 다르므로 적절히 조정이 필요할 수 있습니다.
-        response.put("data", ex.getBindingResult().getTarget());
-
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(CustomException.class)
+    @ResponseBody
+    public ApiResponse customExceptionHandler(CustomException customException) {
+        return new ApiResponse(customException.getStatusCode().getCode(), customException.getMessage());
     }
 }


### PR DESCRIPTION

<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
-  GlobalExceptionHanlder의 exceptionHandler가 모두 ApiResponse를 반환하도록 통일감있게 수정하였습니다.
- CustomException 생성자 매개변수가 data객체를 받지 않도록 수정하였습니다. 

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
