### PR TITLE
Feat: S3이미지 삭제 서비스 구현 및 컬렉션과 멤버 수정 서비스에 추가

### DIFF
--- a/src/main/java/com/pintogether/backend/service/AmazonS3Service.java
+++ b/src/main/java/com/pintogether/backend/service/AmazonS3Service.java
@@ -2,6 +2,7 @@ package com.pintogether.backend.service;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -52,6 +53,10 @@ public class AmazonS3Service {
         String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
         String imageUrl = convertPresignedUrlToImageUrl(presignedUrl);
         return new AmazonS3Response(presignedUrl, imageUrl);
+    }
+
+    public void deleteS3Image(String objectKey) {
+        amazonS3.deleteObject(bucket, objectKey);
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/pintogether/backend/service/MemberService.java
+++ b/src/main/java/com/pintogether/backend/service/MemberService.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +29,14 @@ public class MemberService {
 
     public void update(Long id, UpdateMemberRequestDTO updateMemberRequestDTO) {
         Member foundMember = this.getMember(id);
+        Set<String> defaultImage = new HashSet<>(Arrays.asList(
+                "https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/profile1.png",
+                "https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/profile2.png",
+                "https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/profile3.png"
+        ));
+        if (!defaultImage.contains(foundMember.getAvatar()) && !foundMember.getAvatar().equals(updateMemberRequestDTO.getAvatar())) {
+            amazonS3Service.deleteS3Image(foundMember.getAvatar());
+        }
         foundMember.updateMember(updateMemberRequestDTO);
     }
 


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- S3 이미지 삭제 서비스(`void deleteS3Image(String objectKey)`)를 구현하였습니다.
- 컬렉션 및 아바타에서 이미지 수정시에 기존 이미지를 삭제하도록 서비스 수정하였습니다.

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
