### PR TITLE
Fix 멤버와 컬렉션 생성시 기본이미지로 초기화하기 #103

### DIFF
--- a/src/main/java/com/pintogether/backend/controller/CollectionController.java
+++ b/src/main/java/com/pintogether/backend/controller/CollectionController.java
@@ -35,7 +35,6 @@ public class CollectionController {
         Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
         collectionService.createCollection(memberId, createCollectionRequestDTO);
 
-
         return ApiResponse.makeResponse(StatusCode.CREATED.getCode(), StatusCode.CREATED.getMessage(), response);
     }
 

--- a/src/main/java/com/pintogether/backend/dto/CreateCollectionRequestDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/CreateCollectionRequestDTO.java
@@ -17,9 +17,6 @@ public class CreateCollectionRequestDTO {
     private String title;
 
     @NotNull
-    private String thumbnail;
-
-    @NotNull
     @Size(max = 250, message = "세부내용은 250자 이내로 작성해주세요.")
     private String details;
 

--- a/src/main/java/com/pintogether/backend/entity/Member.java
+++ b/src/main/java/com/pintogether/backend/entity/Member.java
@@ -41,9 +41,9 @@ public class Member {
     private final List<Collection> collections = new ArrayList<>();
 
     @Builder
-    public Member(String nickname, RegistrationSource registrationSource, String registrationId, RoleType roleType) {
-        this.nickname = nickname; // 닉네임 생성기로 생성
-        this.avatar = ""; // 추후에 defualt 이미지 주소로 대치
+    public Member(String nickname, String avatar, RegistrationSource registrationSource, String registrationId, RoleType roleType) {
+        this.nickname = nickname;
+        this.avatar = avatar;
         this.registrationSource = registrationSource;
         this.registrationId = registrationId;
         this.roleType = roleType;

--- a/src/main/java/com/pintogether/backend/service/CollectionService.java
+++ b/src/main/java/com/pintogether/backend/service/CollectionService.java
@@ -63,7 +63,7 @@ public class CollectionService {
         Collection newCollection = Collection.builder()
                 .member(memberService.getMember(memberId))
                 .title(createCollectionRequestDTO.getTitle())
-                .thumbnail(createCollectionRequestDTO.getThumbnail())
+                .thumbnail("https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/collection1.png")
                 .details(createCollectionRequestDTO.getDetails())
                 .build();
 

--- a/src/main/java/com/pintogether/backend/service/MemberService.java
+++ b/src/main/java/com/pintogether/backend/service/MemberService.java
@@ -3,10 +3,13 @@ package com.pintogether.backend.service;
 import com.pintogether.backend.dto.UpdateMemberRequestDTO;
 import com.pintogether.backend.entity.Member;
 import com.pintogether.backend.entity.enums.InterestType;
+import com.pintogether.backend.entity.enums.RegistrationSource;
+import com.pintogether.backend.entity.enums.RoleType;
 import com.pintogether.backend.repository.CollectionRepository;
 import com.pintogether.backend.repository.FollowingRepository;
 import com.pintogether.backend.repository.InterestingCollectionRepository;
 import com.pintogether.backend.repository.MemberRepository;
+import com.pintogether.backend.util.RandomNicknameGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +25,16 @@ public class MemberService {
     private final InterestingCollectionRepository interestingCollectionRepository;
     private final FollowingRepository followingRepository;
     private final AmazonS3Service amazonS3Service;
-
+    public Member createMember(RegistrationSource registrationSource, String registrationId) {
+        Member newMember = Member.builder()
+                .nickname(RandomNicknameGenerator.generateNickname())
+                .avatar("https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/profile1.png")
+                .registrationSource(registrationSource)
+                .registrationId(registrationId)
+                .roleType(RoleType.ROLE_MEMBER)
+                .build();
+        return memberRepository.save(newMember);
+    }
     public Member getMember(Long id) {
         return memberRepository.findOneById(id).orElse(null);
     }
@@ -75,5 +87,9 @@ public class MemberService {
 
     public AmazonS3Service.AmazonS3Response getPresignedUrl(String contentType, String domainType, Long id) {
         return amazonS3Service.getneratePresignedUrlAndImageUrl(contentType, domainType, id);
+    }
+
+    public Member getMemberByRegistrationId(String registrationId) {
+        return memberRepository.findByRegistrationId(registrationId).orElse(null);
     }
 }


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 멤버 서비스에 createMember()를 추가하였습니다. 
- OauthSuccessHandler에서 memberRepository 대신 memberService 사용하도록 수정하였습니다.
- memberCreate(), collectionCreate() 메서드에서 기본이미지로 초기화하도록 하였습니다.

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
