### PR TITLE
Fix:특정 멤버의 콜렉션 목록 조회, 특정 멤버의 스크랩한 콜랙션 목록 조회 API에 비회원도 접근할 수 있도록 수정

### DIFF
--- a/src/main/java/com/pintogether/backend/controller/CollectionController.java
+++ b/src/main/java/com/pintogether/backend/controller/CollectionController.java
@@ -3,6 +3,7 @@ package com.pintogether.backend.controller;
 import com.pintogether.backend.customAnnotations.CurrentCollection;
 import com.pintogether.backend.customAnnotations.CurrentCollectionComment;
 import com.pintogether.backend.customAnnotations.CurrentMember;
+import com.pintogether.backend.customAnnotations.ThisMember;
 import com.pintogether.backend.dto.*;
 import com.pintogether.backend.entity.Collection;
 import com.pintogether.backend.entity.CollectionComment;
@@ -39,8 +40,7 @@ public class CollectionController {
     }
 
     @GetMapping("/{collectionId}")
-    public ApiResponse getCollection(@CurrentCollection Collection collection) {
-        Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+    public ApiResponse getCollection(@ThisMember Member member, @CurrentCollection Collection collection) {
         ShowCollectionResponseDTO showCollectionResponseDTO = ShowCollectionResponseDTO.builder()
                 .id(collection.getId())
                 .title(collection.getTitle())
@@ -51,8 +51,8 @@ public class CollectionController {
                 .likeCnt(collectionService.getLikeCnt(collection.getId()))
                 .pinCnt(collectionService.getPinCnt(collection.getId()))
                 .scrapCnt(collectionService.getScrappedCnt(collection.getId()))
-                .isScrapped(interestingCollectionService.isScrappedByMember(memberId, collection.getId()))
-                .isLiked(interestingCollectionService.isLikedByMember(memberId, collection.getId()))
+                .isScrapped(member!=null ? interestingCollectionService.isScrappedByMember(member.getId(), collection.getId()) : false)
+                .isLiked(member!=null? interestingCollectionService.isLikedByMember(member.getId(), collection.getId()) : false)
                 .tags(collection.getCollectionTags().stream()
                         .map(CollectionTag::getTag)
                         .collect(Collectors.toList()))
@@ -168,45 +168,5 @@ public class CollectionController {
     public ApiResponse getPresignedUrlForThumbnail(@CurrentCollection Collection collection, @RequestBody @Valid S3CollectionThumbnailRequestDTO s3CollectionThumbnailRequestDTO) {
         Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
         return ApiResponse.makeResponse(collectionService.getPresignedUrlForThumbnail(memberId, s3CollectionThumbnailRequestDTO.getContentType(), DomainType.Collection.THUMBNAIL.getName(), collection));
-    }
-
-    @GetMapping("/{targetId}/collections")
-    public ApiResponse getCollectionsByMember(@CurrentMember Member targetMember, @RequestParam("page") int pageNumber, @RequestParam("size") int pageSize) {
-        Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        List<ShowCollectionsResponseDTO> collections = collectionService.getCollectionsByMemberIdWithPageable(targetMember.getId(), pageNumber, pageSize).get()
-                .map(c -> ShowCollectionsResponseDTO.builder()
-                        .id(c.getId())
-                        .title(c.getTitle())
-                        .writerId(c.getMember().getId())
-                        .writer(c.getMember().getNickname())
-                        .thumbnail(c.getThumbnail())
-                        .likeCnt(collectionService.getLikeCnt(c.getId()))
-                        .pinCnt(collectionService.getPinCnt(c.getId()))
-                        .scrapCnt(collectionService.getScrappedCnt(c.getId()))
-                        .isScrapped(!"anonymousUser".equals(memberId) ? interestingCollectionService.isScrappedByMember(memberId, c.getId()) : false)
-                        .isLiked(!"anonymousUser".equals(memberId) ? interestingCollectionService.isLikedByMember(memberId, c.getId()) : false)
-                        .build())
-                .collect(Collectors.toList());
-        return ApiResponse.makeResponse(collections);
-    }
-
-    @GetMapping("/{targetId}/scraps")
-    public ApiResponse getScrapCollectionsByMember(@CurrentMember Member targetMember, @RequestParam("page") int pageNumber, @RequestParam("size") int pageSize) {
-        Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        List<ShowCollectionsResponseDTO> collections = collectionService.getScrapCollectionsByMemberIdWithPageable(targetMember.getId(), pageNumber, pageSize).get()
-                .map(c -> ShowCollectionsResponseDTO.builder()
-                        .id(c.getId())
-                        .title(c.getTitle())
-                        .writerId(c.getMember().getId())
-                        .writer(c.getMember().getNickname())
-                        .thumbnail(c.getThumbnail())
-                        .likeCnt(collectionService.getLikeCnt(c.getId()))
-                        .pinCnt(collectionService.getPinCnt(c.getId()))
-                        .scrapCnt(collectionService.getScrappedCnt(c.getId()))
-                        .isScrapped(!"anonymousUser".equals(memberId) ? interestingCollectionService.isScrappedByMember(memberId, c.getId()) : false)
-                        .isLiked(!"anonymousUser".equals(memberId) ? interestingCollectionService.isLikedByMember(memberId, c.getId()) : false)
-                        .build())
-                .collect(Collectors.toList());
-        return ApiResponse.makeResponse(collections);
     }
 }

--- a/src/main/java/com/pintogether/backend/controller/MemberController.java
+++ b/src/main/java/com/pintogether/backend/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.pintogether.backend.controller;
 
+import com.pintogether.backend.customAnnotations.CurrentMember;
 import com.pintogether.backend.customAnnotations.ThisMember;
 import com.pintogether.backend.dto.*;
 import com.pintogether.backend.entity.Member;
@@ -7,10 +8,7 @@ import com.pintogether.backend.exception.CustomException;
 import com.pintogether.backend.model.ApiResponse;
 import com.pintogether.backend.model.CustomStatusMessage;
 import com.pintogether.backend.model.StatusCode;
-import com.pintogether.backend.service.AmazonS3Service;
-import com.pintogether.backend.service.DomainType;
-import com.pintogether.backend.service.FollowingService;
-import com.pintogether.backend.service.MemberService;
+import com.pintogether.backend.service.*;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +24,8 @@ import java.util.stream.Collectors;
 public class MemberController {
     private final MemberService memberService;
     private final FollowingService followingService;
+    private final CollectionService collectionService;
+    private final InterestingCollectionService interestingCollectionService;
     private final AmazonS3Service amazonS3Service;
 
     @GetMapping("/me")
@@ -128,6 +128,43 @@ public class MemberController {
                         .build())
                 .collect(Collectors.toList());
         return ApiResponse.makeResponse(showSimpleMemberResponseDTOs);
+    }
+    @GetMapping("/{targetId}/collections")
+    public ApiResponse getCollectionsByMember(@ThisMember Member member, @CurrentMember Member targetMember, @RequestParam("page") int pageNumber, @RequestParam("size") int pageSize) {
+        List<ShowCollectionsResponseDTO> collections = collectionService.getCollectionsByMemberIdWithPageable(targetMember.getId(), pageNumber, pageSize).get()
+                .map(c -> ShowCollectionsResponseDTO.builder()
+                        .id(c.getId())
+                        .title(c.getTitle())
+                        .writerId(c.getMember().getId())
+                        .writer(c.getMember().getNickname())
+                        .thumbnail(c.getThumbnail())
+                        .likeCnt(collectionService.getLikeCnt(c.getId()))
+                        .pinCnt(collectionService.getPinCnt(c.getId()))
+                        .scrapCnt(collectionService.getScrappedCnt(c.getId()))
+                        .isScrapped(member != null ? interestingCollectionService.isScrappedByMember(member.getId(), c.getId()) : false)
+                        .isLiked(member != null ? interestingCollectionService.isLikedByMember(member.getId(), c.getId()) : false)
+                        .build())
+                .collect(Collectors.toList());
+        return ApiResponse.makeResponse(collections);
+    }
+
+    @GetMapping("/{targetId}/scraps")
+    public ApiResponse getScrapCollectionsByMember(@ThisMember Member member, @CurrentMember Member targetMember, @RequestParam("page") int pageNumber, @RequestParam("size") int pageSize) {
+        List<ShowCollectionsResponseDTO> collections = collectionService.getScrapCollectionsByMemberIdWithPageable(targetMember.getId(), pageNumber, pageSize).get()
+                .map(c -> ShowCollectionsResponseDTO.builder()
+                        .id(c.getId())
+                        .title(c.getTitle())
+                        .writerId(c.getMember().getId())
+                        .writer(c.getMember().getNickname())
+                        .thumbnail(c.getThumbnail())
+                        .likeCnt(collectionService.getLikeCnt(c.getId()))
+                        .pinCnt(collectionService.getPinCnt(c.getId()))
+                        .scrapCnt(collectionService.getScrappedCnt(c.getId()))
+                        .isScrapped(member!=null ? interestingCollectionService.isScrappedByMember(member.getId(), c.getId()) : false)
+                        .isLiked(member!=null ? interestingCollectionService.isLikedByMember(member.getId(), c.getId()) : false)
+                        .build())
+                .collect(Collectors.toList());
+        return ApiResponse.makeResponse(collections);
     }
 
     @GetMapping("/me/avatar/presigned-url")

--- a/src/main/java/com/pintogether/backend/controller/MemberController.java
+++ b/src/main/java/com/pintogether/backend/controller/MemberController.java
@@ -130,7 +130,7 @@ public class MemberController {
         return ApiResponse.makeResponse(showSimpleMemberResponseDTOs);
     }
     @GetMapping("/{targetId}/collections")
-    public ApiResponse getCollectionsByMember(@ThisMember Member member, @CurrentMember Member targetMember, @RequestParam("page") int pageNumber, @RequestParam("size") int pageSize) {
+    public ApiResponse getCollectionsByMember(@ThisMember Member member, @CurrentMember Member targetMember, @RequestParam(value="page", defaultValue = "0") int pageNumber, @RequestParam(value = "size", defaultValue = "10") int pageSize) {
         List<ShowCollectionsResponseDTO> collections = collectionService.getCollectionsByMemberIdWithPageable(targetMember.getId(), pageNumber, pageSize).get()
                 .map(c -> ShowCollectionsResponseDTO.builder()
                         .id(c.getId())
@@ -149,7 +149,7 @@ public class MemberController {
     }
 
     @GetMapping("/{targetId}/scraps")
-    public ApiResponse getScrapCollectionsByMember(@ThisMember Member member, @CurrentMember Member targetMember, @RequestParam("page") int pageNumber, @RequestParam("size") int pageSize) {
+    public ApiResponse getScrapCollectionsByMember(@ThisMember Member member, @CurrentMember Member targetMember,  @RequestParam(value="page", defaultValue = "0") int pageNumber, @RequestParam(value = "size", defaultValue = "10") int pageSize) {
         List<ShowCollectionsResponseDTO> collections = collectionService.getScrapCollectionsByMemberIdWithPageable(targetMember.getId(), pageNumber, pageSize).get()
                 .map(c -> ShowCollectionsResponseDTO.builder()
                         .id(c.getId())


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 아래 2개 API에 비회원도 접근할 수 있도록 수정하였습니다.
- 특정 멤버의 콜렉션 목록 조회 API
- 특정 멤버의 스크랩한 콜랙션 목록 조회 API


<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
