### PR TITLE
Fix: collection 생성 API 반환 값 수정

### DIFF
--- a/src/main/java/com/pintogether/backend/controller/CollectionController.java
+++ b/src/main/java/com/pintogether/backend/controller/CollectionController.java
@@ -32,11 +32,13 @@ public class CollectionController {
     private final PinService pinService;
 
     @PostMapping("")
-    public ApiResponse createCollection(@RequestBody @Valid CreateCollectionRequestDTO createCollectionRequestDTO, HttpServletResponse response) {
-        Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
-        collectionService.createCollection(memberId, createCollectionRequestDTO);
-
-        return ApiResponse.makeResponse(StatusCode.CREATED.getCode(), StatusCode.CREATED.getMessage(), response);
+    public ApiResponse createCollection(@ThisMember Member member, @RequestBody @Valid CreateCollectionRequestDTO createCollectionRequestDTO) {
+        Collection newCollection = collectionService.createCollection(member.getId(), createCollectionRequestDTO);
+        if (createCollectionRequestDTO.getContentType() == null) {
+            return ApiResponse.makeResponse(CreateCollectionResponseDTO.builder().id(newCollection.getId()).build());
+        } else {
+            return ApiResponse.makeResponse(collectionService.getPresignedUrlForThumbnail(member.getId(), createCollectionRequestDTO.getContentType(), DomainType.Collection.THUMBNAIL.getName(), newCollection));
+        }
     }
 
     @GetMapping("/{collectionId}")

--- a/src/main/java/com/pintogether/backend/dto/CreateCollectionRequestDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/CreateCollectionRequestDTO.java
@@ -1,6 +1,7 @@
 package com.pintogether.backend.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,4 +23,7 @@ public class CreateCollectionRequestDTO {
 
     @Size(max = 5, message = "태그는 5개 이내만 가능합니다.")
     private List<@Size(max = 20, message = "각 태그는 20자 이내로 작성해주세요.") String> tags;
+
+    @Pattern(regexp = "(?i)image/jpeg|image/png|image/jpg", message = "유효하지 않은 타입입니다. 제공하는 타입은 image/jpeg, image/png, image/jpg 입니다.")
+    private String contentType;
 }

--- a/src/main/java/com/pintogether/backend/dto/CreateCollectionResponseDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/CreateCollectionResponseDTO.java
@@ -1,0 +1,14 @@
+package com.pintogether.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class CreateCollectionResponseDTO {
+    private Long id;
+}

--- a/src/main/java/com/pintogether/backend/service/AmazonS3Service.java
+++ b/src/main/java/com/pintogether/backend/service/AmazonS3Service.java
@@ -52,7 +52,7 @@ public class AmazonS3Service {
                 .withContentType(contentType);
         String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
         String imageUrl = convertPresignedUrlToImageUrl(presignedUrl);
-        return new AmazonS3Response(presignedUrl, imageUrl);
+        return new AmazonS3Response(id, presignedUrl, imageUrl);
     }
 
     public void deleteS3Image(String objectKey) {
@@ -62,6 +62,7 @@ public class AmazonS3Service {
     @AllArgsConstructor
     @Getter
     public static class AmazonS3Response {
+        private Long id;
         private String presignedUrl;
         private String imageUrl;
     }

--- a/src/main/java/com/pintogether/backend/service/CollectionService.java
+++ b/src/main/java/com/pintogether/backend/service/CollectionService.java
@@ -12,6 +12,7 @@ import com.pintogether.backend.model.StatusCode;
 import com.pintogether.backend.repository.CollectionCommentRepository;
 import com.pintogether.backend.repository.CollectionRepository;
 import com.pintogether.backend.repository.InterestingCollectionRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -59,7 +60,7 @@ public class CollectionService {
         }
         this.collectionRepository.delete(collection);
     }
-    public void createCollection(Long memberId, CreateCollectionRequestDTO createCollectionRequestDTO) {
+    public Collection createCollection(Long memberId, CreateCollectionRequestDTO createCollectionRequestDTO) {
         Collection newCollection = Collection.builder()
                 .member(memberService.getMember(memberId))
                 .title(createCollectionRequestDTO.getTitle())
@@ -74,6 +75,7 @@ public class CollectionService {
                         .build())
                 .collect(Collectors.toList());
         collectionRepository.save(newCollection);
+        return newCollection;
     }
 
     public void updateCollection(Long memberId, Long collectionId, UpdateCollectionRequestDTO updateCollectionRequestDTO) {


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- collection 생성시 컨텐츠타입 필드를 받지 않으면 presigned-url이 없이 컬렉션 Id만 반환하고, 
컨텐츠 타입 필드가 존재하면 presigned-url을 함께 반환하도록 수정하였습니다.
- 

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
