### PR TITLE
Feat: 소켓서비스 수정, 알림 목록 조회 api 및 새로운 알림 갯수 조회 api 완성

### DIFF
--- a/src/main/java/com/pintogether/backend/controller/MemberController.java
+++ b/src/main/java/com/pintogether/backend/controller/MemberController.java
@@ -80,6 +80,7 @@ public class MemberController {
             throw new CustomException(StatusCode.NOT_FOUND, CustomStatusMessage.MEMBER_NOT_FOUND.getMessage());
         }
         ShowOtherMemberResponseDTO showOtherMemberResponseDTO = ShowOtherMemberResponseDTO.builder()
+                .id(targetMember.getId())
                 .name(targetMember.getName())
                 .membername(targetMember.getMembername())
                 .avatar(targetMember.getAvatar())
@@ -100,6 +101,7 @@ public class MemberController {
             throw new CustomException(StatusCode.NOT_FOUND, CustomStatusMessage.MEMBER_NOT_FOUND.getMessage());
         }
         ShowOtherMemberResponseDTO showOtherMemberResponseDTO = ShowOtherMemberResponseDTO.builder()
+                .id(targetId)
                 .name(targetMember.getName())
                 .membername(targetMember.getMembername())
                 .avatar(targetMember.getAvatar())

--- a/src/main/java/com/pintogether/backend/dto/ShowAlertCntResponseDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/ShowAlertCntResponseDTO.java
@@ -1,0 +1,28 @@
+package com.pintogether.backend.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pintogether.backend.exception.CustomException;
+import com.pintogether.backend.model.StatusCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class ShowAlertCntResponseDTO {
+    private int alertCnt;
+
+    @Override
+    public String toString() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, "JSON 파싱 중 예기치 않은 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/pintogether/backend/dto/ShowNotificationResponseDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/ShowNotificationResponseDTO.java
@@ -1,28 +1,18 @@
 package com.pintogether.backend.dto;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pintogether.backend.exception.CustomException;
-import com.pintogether.backend.model.StatusCode;
-import com.pintogether.backend.websocket.NotificationType;
-import lombok.*;
+import com.pintogether.backend.entity.enums.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Builder
 public class ShowNotificationResponseDTO {
+    private Long subjectId;
     private String subject;
     private NotificationType notificationType;
     private String object;
-
-    @Override
-    public String toString() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            return objectMapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, "JSON 파싱 중 예기치 않은 오류가 발생했습니다.");
-        }
-    }
 }

--- a/src/main/java/com/pintogether/backend/dto/ShowNotificationsResponseDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/ShowNotificationsResponseDTO.java
@@ -1,0 +1,19 @@
+package com.pintogether.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class ShowNotificationsResponseDTO {
+    private List<ShowNotificationResponseDTO> today;
+    private List<ShowNotificationResponseDTO> yesterday;
+    private List<ShowNotificationResponseDTO> aWeekAgo;
+    private List<ShowNotificationResponseDTO> withinAMonth;
+}

--- a/src/main/java/com/pintogether/backend/dto/ShowOtherMemberResponseDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/ShowOtherMemberResponseDTO.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 public class ShowOtherMemberResponseDTO {
+    private Long id;
+
     private String name;
 
     private String membername;

--- a/src/main/java/com/pintogether/backend/entity/Member.java
+++ b/src/main/java/com/pintogether/backend/entity/Member.java
@@ -45,6 +45,8 @@ public class Member {
     @NotNull
     private RoleType roleType;
 
+    private int alertCnt;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private final List<Collection> collections = new ArrayList<>();
 
@@ -57,6 +59,7 @@ public class Member {
         this.registrationSource = registrationSource;
         this.registrationId = registrationId;
         this.roleType = roleType;
+        this.alertCnt = 0;
     }
 
     public void updateMember(final UpdateMemberRequestDTO updateMemberRequestDTO) {
@@ -66,4 +69,10 @@ public class Member {
         this.bio = updateMemberRequestDTO.getBio();
     }
 
+    public void increaseAlertCnt() {
+        this.alertCnt += 1;
+    }
+    public void clearAlertCnt() {
+        this.alertCnt = 0;
+    }
 }

--- a/src/main/java/com/pintogether/backend/entity/Notification.java
+++ b/src/main/java/com/pintogether/backend/entity/Notification.java
@@ -1,0 +1,37 @@
+package com.pintogether.backend.entity;
+
+import com.pintogether.backend.entity.enums.NotificationType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
+
+    @Enumerated(value = EnumType.STRING)
+    @NotNull
+    private NotificationType notificationType;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private Member subject;
+
+    private String object;
+}

--- a/src/main/java/com/pintogether/backend/entity/enums/NotificationType.java
+++ b/src/main/java/com/pintogether/backend/entity/enums/NotificationType.java
@@ -1,4 +1,4 @@
-package com.pintogether.backend.websocket;
+package com.pintogether.backend.entity.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/com/pintogether/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.pintogether.backend.repository;
+
+import com.pintogether.backend.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    public List<Notification> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/pintogether/backend/service/MemberService.java
+++ b/src/main/java/com/pintogether/backend/service/MemberService.java
@@ -95,4 +95,14 @@ public class MemberService {
     public Member getMemberByMembername(String membername) {
         return memberRepository.findOneByMembername(membername).orElse(null);
     }
+
+    public void increaeAlertCnt(Member member) {
+        member.increaseAlertCnt();
+        memberRepository.save(member);
+    }
+
+    public void clearAlertCnt(Member member) {
+        member.clearAlertCnt();
+        memberRepository.save(member);
+    }
 }

--- a/src/main/java/com/pintogether/backend/service/NotificationService.java
+++ b/src/main/java/com/pintogether/backend/service/NotificationService.java
@@ -1,0 +1,88 @@
+package com.pintogether.backend.service;
+
+import com.pintogether.backend.entity.Collection;
+import com.pintogether.backend.entity.Member;
+import com.pintogether.backend.entity.Notification;
+import com.pintogether.backend.entity.enums.NotificationType;
+import com.pintogether.backend.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberService memberService;
+
+    // 내가 누군가의 컬렉션을 스크랩해서 그 컬렉션 주인에게 알림이 생성됌
+    public void scrapCollection(Member member, Collection collection) {
+        Notification notification = Notification.builder()
+                .member(collection.getMember())
+                .subject(member)
+                .notificationType(NotificationType.SCRAP_COLLECTION)
+                .object(collection.getTitle())
+                .build();
+        notificationRepository.save(notification);
+        memberService.increaeAlertCnt(collection.getMember());
+    }
+
+    // 내가 누군가의 컬렉션에 댓글을 달아서 그 컬렉션 주인에게 알림이 생성됌
+    public void commentOnCollection(Member member, Collection collection) {
+        Notification notification = Notification.builder()
+                .member(collection.getMember())
+                .subject(member)
+                .notificationType(NotificationType.COMMENT_ON_COLLECTION)
+                .object(collection.getTitle())
+                .build();
+        notificationRepository.save(notification);
+        memberService.increaeAlertCnt(collection.getMember());
+    }
+
+    // 내가 누군가의 컬렉션에 좋아요를 눌러서 좋아요 당한 사람에게 알림이 생성됌
+    public void likeCollection(Member member, Collection collection) {
+        Notification notification = Notification.builder()
+                .member(collection.getMember())
+                .subject(member)
+                .notificationType(NotificationType.LIKE_COLLECTION)
+                .object(collection.getTitle())
+                .build();
+        notificationRepository.save(notification);
+        memberService.increaeAlertCnt(collection.getMember());
+    }
+
+    // 내가 팔로우를 해서 팔로우 당한 사람에게 알림이 생성됌
+    public void follow(Member member, Member followee) {
+        Notification notification = Notification.builder()
+                .member(followee)
+                .subject(member)
+                .notificationType(NotificationType.FOLLOW)
+                .object(null)
+                .build();
+        notificationRepository.save(notification);
+        memberService.increaeAlertCnt(followee);
+    }
+
+    // 내가 새로운 컬렉션을 생성해서 나를 팔로우하던 사람들에게 알림이 생성됌
+    public void createCollection(Member member, Collection collection) {
+        for (Member follower: memberService.getFollowers(member.getId())) {
+            Notification notification = Notification.builder()
+                    .member(follower)
+                    .subject(member)
+                    .notificationType(NotificationType.CREATE_COLLECTION)
+                    .object(collection.getTitle())
+                    .build();
+            notificationRepository.save(notification);
+            memberService.increaeAlertCnt(follower);
+        }
+    }
+
+    public List<Notification> getAllNotification(Member member) {
+        memberService.clearAlertCnt(member);
+        return notificationRepository.findAllByMemberId(member.getId());
+    }
+}

--- a/src/main/java/com/pintogether/backend/websocket/WebSocketService.java
+++ b/src/main/java/com/pintogether/backend/websocket/WebSocketService.java
@@ -1,8 +1,6 @@
 package com.pintogether.backend.websocket;
 
-import com.pintogether.backend.dto.ShowNotificationResponseDTO;
-import com.pintogether.backend.entity.Collection;
-import com.pintogether.backend.entity.CollectionComment;
+import com.pintogether.backend.dto.ShowAlertCntResponseDTO;
 import com.pintogether.backend.entity.Member;
 import com.pintogether.backend.exception.CustomException;
 import com.pintogether.backend.model.CustomStatusMessage;
@@ -21,83 +19,27 @@ public class WebSocketService {
     private final WebSocketHandler webSocketHandler;
     private final MemberService memberService;
 
-    public void scrapCollection(Member collector, Collection collection) {
-        ShowNotificationResponseDTO showNotificationResponseDTO = ShowNotificationResponseDTO.builder()
-                .subject(collector.getMembername())
-                .notificationType(NotificationType.SCRAP_COLLECTION)
-                .object(collection.getTitle())
+    public void sendNotificationCntToMember(Member member) {
+        ShowAlertCntResponseDTO showAlertCntResponseDTO = ShowAlertCntResponseDTO.builder()
+                .alertCnt(member.getAlertCnt())
                 .build();
         try {
-            webSocketHandler.sendMessageToMember(collection.getMember().getId(), showNotificationResponseDTO.toString());
+            webSocketHandler.sendMessageToMember(member.getId(), showAlertCntResponseDTO.toString());
         } catch (IOException e) {
             throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
         }
     }
 
-    public void commentOnCollection(Member writer, Collection collection) {
-        ShowNotificationResponseDTO showNotificationResponseDTO = ShowNotificationResponseDTO.builder()
-                .subject(writer.getMembername())
-                .notificationType(NotificationType.COMMENT_ON_COLLECTION)
-                .object(collection.getTitle())
-                .build();
-        try {
-            webSocketHandler.sendMessageToMember(collection.getMember().getId(), showNotificationResponseDTO.toString());
-        } catch (IOException e) {
-            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
-        }
-    }
-
-    public void likeCollection(Member liker, Collection collection) {
-        ShowNotificationResponseDTO showNotificationResponseDTO = ShowNotificationResponseDTO.builder()
-                .subject(liker.getMembername())
-                .notificationType(NotificationType.LIKE_COLLECTION)
-                .object(collection.getTitle())
-                .build();
-        try {
-            webSocketHandler.sendMessageToMember(collection.getMember().getId(), showNotificationResponseDTO.toString());
-        } catch (IOException e) {
-            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
-        }
-    }
-
-    public void follow(Member follower, Member followee) {
-        ShowNotificationResponseDTO showNotificationResponseDTO = ShowNotificationResponseDTO.builder()
-                .subject(follower.getMembername())
-                .notificationType(NotificationType.FOLLOW)
-                .object(null)
-                .build();
-        try {
-            webSocketHandler.sendMessageToMember(followee.getId(), showNotificationResponseDTO.toString());
-        } catch (IOException e) {
-            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
-        }
-    }
-
-    public void createCollection(Member creator, Collection collection) {
-        ShowNotificationResponseDTO showNotificationResponseDTO = ShowNotificationResponseDTO.builder()
-                .subject(creator.getMembername())
-                .notificationType(NotificationType.CREATE_COLLECTION)
-                .object(collection.getTitle())
-                .build();
-        try {
-            for (Member follower: memberService.getFollowers(creator.getId())) {
-                webSocketHandler.sendMessageToMember(follower.getId(), showNotificationResponseDTO.toString());
+    public void sendNotificationCntToFollower(Member member) {
+        for (Member follower: memberService.getFollowers(member.getId())) {
+            ShowAlertCntResponseDTO showAlertCntResponseDTO = ShowAlertCntResponseDTO.builder()
+                    .alertCnt(follower.getAlertCnt())
+                    .build();
+            try {
+                webSocketHandler.sendMessageToMember(follower.getId(), showAlertCntResponseDTO.toString());
+            } catch (IOException e) {
+                throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
             }
-        } catch (IOException e) {
-            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
-        }
-    }
-
-    public void removeComment(CollectionComment collectionComment) {
-        ShowNotificationResponseDTO showNotificationResponseDTO = ShowNotificationResponseDTO.builder()
-                .subject(null)
-                .notificationType(NotificationType.COMMENT_DELETED)
-                .object(collectionComment.getCollection().getTitle())
-                .build();
-        try {
-            webSocketHandler.sendMessageToMember(collectionComment.getMember().getId(), showNotificationResponseDTO.toString());
-        } catch (IOException e) {
-            throw new CustomException(StatusCode.INTERNAL_SERVER_ERROR, CustomStatusMessage.SOCKET_IO_EXCEPTION.getMessage());
         }
     }
 }


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 알림 내역을 저장하기 위해서 notification 엔티티와 repository, service 클래스를 생성 및 구현하였습니다.
- 멤버 엔티티에 alertCnt 필드를 추가해서 읽지 않은 알림을 저장하도록 하였습니다.
- 기존 소켓서비스를 소켓메시지 반환형식이 바뀜에 따라 적절하게 수정하였습니다.
- 알림 목록 조회 API, 알림 갯수 조회 API 구현 완료하였습니다.
- 특정 유저 정보 조회API 반환 리소스에 멤버 Id를 추가하였습니다.

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
