### PR TITLE
refector: 이미 선언해놓은 now 변수 사용하도록 코드 수정

### DIFF
--- a/src/main/java/com/pintogether/backend/controller/MemberController.java
+++ b/src/main/java/com/pintogether/backend/controller/MemberController.java
@@ -11,7 +11,6 @@ import com.pintogether.backend.model.ApiResponse;
 import com.pintogether.backend.model.CustomStatusMessage;
 import com.pintogether.backend.model.StatusCode;
 import com.pintogether.backend.service.*;
-import com.pintogether.backend.websocket.WebSocketHandler;
 import com.pintogether.backend.websocket.WebSocketService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -19,13 +18,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static java.time.LocalDate.now;
 
 @RequiredArgsConstructor
 @RestController
@@ -257,9 +253,9 @@ public class MemberController {
                 today.add(dto);
             } else if (notificationDate.equals(now.minusDays(1))) {
                 yesterday.add(dto);
-            } else if (notificationDate.isAfter(now.minusWeeks(1)) && !notificationDate.isEqual(now().minusDays(1))) {
+            } else if (notificationDate.isAfter(now.minusWeeks(1)) && !notificationDate.isEqual(now.minusDays(1))) {
                 aWeekAgo.add(dto);
-            } else if (notificationDate.isAfter(now.minusMonths(1)) && notificationDate.isBefore(now().minusWeeks(1))) {
+            } else if (notificationDate.isAfter(now.minusMonths(1)) && notificationDate.isBefore(now.minusWeeks(1))) {
                 withinAMonth.add(dto);
             }
         }


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 불필요하게 선언한 변수 now() -> now로 수정하였습니다.
- 

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
