### PR TITLE
fix: restentrypoint send for whole error not only for 401

### DIFF
--- a/src/main/java/com/pintogether/backend/auth/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/pintogether/backend/auth/RestAuthenticationEntryPoint.java
@@ -12,8 +12,7 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write("{\"message\": \"Access Denied: Unauthorized access.\"}");
+        response.getWriter().write("{\"status\": {\"code\": " + response.getStatus() + ", \"message\": \"something wrong in server.\"}");
     }
 
 }


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- RestAuthenticationEntryPoint 401 고정 -> 모든 에러
-  

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
- #183 
- 

<br/>

## 📸 ScreenShot
-

<br/>
