### PR TITLE
Fix security filter #185

### DIFF
--- a/src/main/java/com/pintogether/backend/auth/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/pintogether/backend/auth/RestAuthenticationEntryPoint.java
@@ -12,7 +12,11 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"status\": {\"code\": " + response.getStatus() + ", \"message\": \"something wrong in server.\"}");
+        switch (response.getStatus()) {
+            case 401 -> response.getWriter().write("{\"status\": {\"code\": " + response.getStatus() + ", \"message\": \"유효하지 않는 멤버입니다.\"}}");
+            case 403 -> response.getWriter().write("{\"status\": {\"code\": " + response.getStatus() + ", \"message\": \"권한이 없습니다.\"}}");
+            case 500 -> response.getWriter().write("{\"status\": {\"code\": " + response.getStatus() + ", \"message\": \"요청 처리 중 에러 발생.\"}}");
+        }
     }
 
 }

--- a/src/main/java/com/pintogether/backend/config/SecurityConfig.java
+++ b/src/main/java/com/pintogether/backend/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                                     new AntPathRequestMatcher("/places"),
                                     new AntPathRequestMatcher("/places/{\\d+}/pins"),
                                     new AntPathRequestMatcher("/places/{place_id}"),
-                                    new AntPathRequestMatcher("/search/**")
+                                    new AntPathRequestMatcher("/search/collections**"),
+                                    new AntPathRequestMatcher("/search/places**")
                             )
                                 .permitAll()
                             .anyRequest()

--- a/src/main/java/com/pintogether/backend/controller/SearchController.java
+++ b/src/main/java/com/pintogether/backend/controller/SearchController.java
@@ -81,9 +81,6 @@ public class SearchController {
     @GetMapping("/history")
     public ApiResponse searchHistory(@ThisMember Member member,
                                      @RequestParam(value = "type", defaultValue = "TOTAL") SearchType searchType) {
-        if (member == null) {
-            return ApiResponse.makeResponse(new ArrayList<>());
-        }
         return ApiResponse.makeResponse(searchService.getSearchHistory(member, searchType).stream()
                 .map(h -> ShowSearchHistoryResponseDTO.builder()
                         .id(h.getId())

--- a/src/main/java/com/pintogether/backend/controller/SearchController.java
+++ b/src/main/java/com/pintogether/backend/controller/SearchController.java
@@ -81,6 +81,9 @@ public class SearchController {
     @GetMapping("/history")
     public ApiResponse searchHistory(@ThisMember Member member,
                                      @RequestParam(value = "type", defaultValue = "TOTAL") SearchType searchType) {
+        if (member == null) {
+            return ApiResponse.makeResponse(new ArrayList<>());
+        }
         return ApiResponse.makeResponse(searchService.getSearchHistory(member, searchType).stream()
                 .map(h -> ShowSearchHistoryResponseDTO.builder()
                         .id(h.getId())

--- a/src/main/java/com/pintogether/backend/service/SqlPlaceSearchImpl.java
+++ b/src/main/java/com/pintogether/backend/service/SqlPlaceSearchImpl.java
@@ -109,6 +109,9 @@ public class SqlPlaceSearchImpl implements SearchService {
         SearchHistory history = searchHistoryRepository.findById(id).orElseThrow(
                 () -> new CustomException(StatusCode.NOT_FOUND, "해당 검색 기록을 찾을 수 없습니다.")
         );
+        if (history.getMember() == null) {
+            throw new CustomException(StatusCode.NOT_FOUND, "탈퇴한 회원의 기록입니다.");
+        }
         if (history.getMember().getId().equals(member.getId())) {
             searchHistoryRepository.delete(history);
         } else {


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- security filter 에 antpathmatcher 추가
- SecurityFilter  search endpoint에 대해 경로 상세하게 제한. (search** -> search/collections**)
- RestAuthenticationEntryPoint 401 만 반환 -> 401 403 500모두
- history 삭제요청시 탈퇴한 멤버에 대한 널포인터 익셉션 처리

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
- #185 
- 

<br/>

## 📸 ScreenShot
-

<br/>
