### PR TITLE
Fix: 알림 목록 조회시 objectId 함께 반환하도록 수정 #206

### DIFF
--- a/src/main/java/com/pintogether/backend/controller/MemberController.java
+++ b/src/main/java/com/pintogether/backend/controller/MemberController.java
@@ -244,6 +244,7 @@ public class MemberController {
                     .subjectId(notification.getSubject() != null ? notification.getSubject().getId() : -1)
                     .subject(notification.getSubject() != null ? notification.getSubject().getMembername() : "탈퇴한 회원")
                     .notificationType(notification.getNotificationType())
+                    .objectId(notification.getObjectId())
                     .object(notification.getObject())
                     .build();
 

--- a/src/main/java/com/pintogether/backend/dto/ShowNotificationResponseDTO.java
+++ b/src/main/java/com/pintogether/backend/dto/ShowNotificationResponseDTO.java
@@ -14,5 +14,6 @@ public class ShowNotificationResponseDTO {
     private Long subjectId;
     private String subject;
     private NotificationType notificationType;
+    private Long objectId;
     private String object;
 }

--- a/src/main/java/com/pintogether/backend/entity/Notification.java
+++ b/src/main/java/com/pintogether/backend/entity/Notification.java
@@ -33,5 +33,7 @@ public class Notification extends BaseEntity {
     @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member subject;
 
+    private Long objectId;
+
     private String object;
 }

--- a/src/main/java/com/pintogether/backend/service/NotificationService.java
+++ b/src/main/java/com/pintogether/backend/service/NotificationService.java
@@ -25,6 +25,7 @@ public class NotificationService {
                 .member(collection.getMember())
                 .subject(member)
                 .notificationType(NotificationType.SCRAP_COLLECTION)
+                .objectId(collection.getId())
                 .object(collection.getTitle())
                 .build();
         notificationRepository.save(notification);
@@ -37,6 +38,7 @@ public class NotificationService {
                 .member(collection.getMember())
                 .subject(member)
                 .notificationType(NotificationType.COMMENT_ON_COLLECTION)
+                .objectId(collection.getId())
                 .object(collection.getTitle())
                 .build();
         notificationRepository.save(notification);
@@ -49,6 +51,7 @@ public class NotificationService {
                 .member(collection.getMember())
                 .subject(member)
                 .notificationType(NotificationType.LIKE_COLLECTION)
+                .objectId(collection.getId())
                 .object(collection.getTitle())
                 .build();
         notificationRepository.save(notification);
@@ -61,6 +64,7 @@ public class NotificationService {
                 .member(followee)
                 .subject(member)
                 .notificationType(NotificationType.FOLLOW)
+                .objectId(null)
                 .object(null)
                 .build();
         notificationRepository.save(notification);
@@ -74,6 +78,7 @@ public class NotificationService {
                     .member(follower)
                     .subject(member)
                     .notificationType(NotificationType.CREATE_COLLECTION)
+                    .objectId(collection.getId())
                     .object(collection.getTitle())
                     .build();
             notificationRepository.save(notification);


### PR DESCRIPTION
…직 수정

<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 알림 목록 조회시 objectId를 함께 반환하여 링크를 걸수있도록 관련 코드 수정하였습니다.
   - Notification 엔티티에 Long objectId 필드 추가하였습니다.
   - ShowNotificationResponseDTO에 Long objectId 필드 추가하였습니다.
   - NotificationService 클래스 메서드에서 관련 로직 수정하였습니다.

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
