### PR TITLE
Feature/soft delete 적용 #225

### DIFF
--- a/src/main/java/com/pintogether/backend/entity/Collection.java
+++ b/src/main/java/com/pintogether/backend/entity/Collection.java
@@ -1,11 +1,14 @@
 package com.pintogether.backend.entity;
 
+import com.pintogether.backend.entity.enums.EntityStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
@@ -16,6 +19,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE collection SET entity_status='DELETE' WHERE id=?")
 public class Collection extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,6 +49,9 @@ public class Collection extends BaseEntity {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/com/pintogether/backend/entity/CollectionComment.java
+++ b/src/main/java/com/pintogether/backend/entity/CollectionComment.java
@@ -1,17 +1,22 @@
 package com.pintogether.backend.entity;
 
+import com.pintogether.backend.entity.enums.EntityStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE collection_comment SET entity_status='DELETE' WHERE id=?")
 public class CollectionComment extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,6 +29,9 @@ public class CollectionComment extends BaseEntity {
 
     @NotNull
     private String contents;
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
 
     CollectionComment(Collection collection, Member member, String contents) {
         this.collection = collection;

--- a/src/main/java/com/pintogether/backend/entity/CollectionTag.java
+++ b/src/main/java/com/pintogether/backend/entity/CollectionTag.java
@@ -1,13 +1,19 @@
 package com.pintogether.backend.entity;
 
+import com.pintogether.backend.entity.enums.EntityStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 @Entity
 @NoArgsConstructor
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE collection_tag SET entity_status='DELETE' WHERE id=?")
 public class CollectionTag {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -17,6 +23,9 @@ public class CollectionTag {
 
     @NotNull
     private String tag;
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
 
     @Builder
     public CollectionTag(Collection collection, String tag) {

--- a/src/main/java/com/pintogether/backend/entity/Complaint.java
+++ b/src/main/java/com/pintogether/backend/entity/Complaint.java
@@ -24,12 +24,10 @@ public class Complaint extends BaseEntity{
 
     @ManyToOne
     @JoinColumn(name = "reporter_id")
-    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member reporter;
 
     @ManyToOne
     @JoinColumn(name = "target_member_id")
-    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member targetMember;
 
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/pintogether/backend/entity/Following.java
+++ b/src/main/java/com/pintogether/backend/entity/Following.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.Where;
+
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/pintogether/backend/entity/Following.java
+++ b/src/main/java/com/pintogether/backend/entity/Following.java
@@ -19,10 +19,8 @@ public class Following {
     private Long id;
 
     @ManyToOne(optional = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member follower;
 
     @ManyToOne(optional = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member followee;
 }

--- a/src/main/java/com/pintogether/backend/entity/InterestingCollection.java
+++ b/src/main/java/com/pintogether/backend/entity/InterestingCollection.java
@@ -23,11 +23,9 @@ public class InterestingCollection {
     private Long id;
 
     @ManyToOne(optional = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @ManyToOne(optional = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Collection collection;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/pintogether/backend/entity/InterestingCollection.java
+++ b/src/main/java/com/pintogether/backend/entity/InterestingCollection.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.Where;
+
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/pintogether/backend/entity/Member.java
+++ b/src/main/java/com/pintogether/backend/entity/Member.java
@@ -1,6 +1,7 @@
 package com.pintogether.backend.entity;
 
 import com.pintogether.backend.dto.UpdateMemberRequestDTO;
+import com.pintogether.backend.entity.enums.EntityStatus;
 import com.pintogether.backend.entity.enums.RegistrationSource;
 import com.pintogether.backend.entity.enums.RoleType;
 import jakarta.persistence.*;
@@ -9,6 +10,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +19,8 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE member SET entity_status='DELETE' WHERE id=?")
 public class Member {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,6 +54,9 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private final List<Collection> collections = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
 
     @Builder
     public Member(String name, String membername, String bio, String avatar, RegistrationSource registrationSource, String registrationId, RoleType roleType) {

--- a/src/main/java/com/pintogether/backend/entity/Notification.java
+++ b/src/main/java/com/pintogether/backend/entity/Notification.java
@@ -22,7 +22,6 @@ public class Notification extends BaseEntity {
     private Long id;
 
     @ManyToOne(optional = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Enumerated(value = EnumType.STRING)
@@ -30,7 +29,6 @@ public class Notification extends BaseEntity {
     private NotificationType notificationType;
 
     @ManyToOne
-    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member subject;
 
     private Long objectId;

--- a/src/main/java/com/pintogether/backend/entity/Pin.java
+++ b/src/main/java/com/pintogether/backend/entity/Pin.java
@@ -1,9 +1,12 @@
 package com.pintogether.backend.entity;
 
 import com.pintogether.backend.dto.ShowPinResponseDTO;
+import com.pintogether.backend.entity.enums.EntityStatus;
 import com.pintogether.backend.util.DateConverter;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +16,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE pin SET collection_status='DELETE' WHERE id=?")
 public class Pin extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,6 +37,9 @@ public class Pin extends BaseEntity {
 
     @OneToMany(mappedBy = "pin", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<PinImage> pinImages = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
     public void updateReview(String review) {
         this.review = review;
     }

--- a/src/main/java/com/pintogether/backend/entity/PinImage.java
+++ b/src/main/java/com/pintogether/backend/entity/PinImage.java
@@ -1,14 +1,19 @@
 package com.pintogether.backend.entity;
 
+import com.pintogether.backend.entity.enums.EntityStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE pin_image SET collection_status='DELETE' WHERE id=?")
 public class PinImage {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -18,6 +23,9 @@ public class PinImage {
 
     @NotNull
     private String imagePath;
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
 
     @Builder
     public PinImage(Pin pin, String imagePath) {

--- a/src/main/java/com/pintogether/backend/entity/PinTag.java
+++ b/src/main/java/com/pintogether/backend/entity/PinTag.java
@@ -1,14 +1,19 @@
 package com.pintogether.backend.entity;
 
+import com.pintogether.backend.entity.enums.EntityStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@Where(clause = "entity_status='ACTIVE'")
+@SQLDelete(sql = "UPDATE pin_tag SET collection_status='DELETE' WHERE id=?")
 public class PinTag {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -19,6 +24,9 @@ public class PinTag {
     @NotNull
     @Column(length = 20)
     private String tag;
+
+    @Enumerated(EnumType.STRING)
+    private EntityStatus entityStatus;
 
     @Builder
     public PinTag(Pin pin, String tag) {

--- a/src/main/java/com/pintogether/backend/entity/SearchHistory.java
+++ b/src/main/java/com/pintogether/backend/entity/SearchHistory.java
@@ -22,7 +22,6 @@ public class SearchHistory extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = true)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member member;
 
     private String query;

--- a/src/main/java/com/pintogether/backend/entity/enums/EntityStatus.java
+++ b/src/main/java/com/pintogether/backend/entity/enums/EntityStatus.java
@@ -1,0 +1,5 @@
+package com.pintogether.backend.entity.enums;
+
+public enum EntityStatus {
+    ACTIVE, DELETE
+}

--- a/src/main/java/com/pintogether/backend/repository/ComplaintRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/ComplaintRepository.java
@@ -4,11 +4,21 @@ import com.pintogether.backend.entity.Complaint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
-
     Page<Complaint> findByReporterId(Pageable pageable, Long reporterId);
 
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE Complaint c SET c.reporter = NULL WHERE c.reporter.id = :id")
+    void updateReporterToNull(@Param("id") Long reporterId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE Complaint c SET c.targetMember = NULL WHERE c.targetMember.id = :id")
+    void updateTargetMemberToNull(@Param("id") Long targetMemberId);
 }

--- a/src/main/java/com/pintogether/backend/repository/FollowingRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/FollowingRepository.java
@@ -3,6 +3,7 @@ package com.pintogether.backend.repository;
 import com.pintogether.backend.entity.Following;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowingRepository extends JpaRepository<Following, Long> {
@@ -13,5 +14,9 @@ public interface FollowingRepository extends JpaRepository<Following, Long> {
     boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
     Optional<Following> findByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+
+    List<Following> findAllByFolloweeId(Long followeeId);
+
+    List<Following> findAllByFollowerId(Long followerId);
 
 }

--- a/src/main/java/com/pintogether/backend/repository/InterestingCollectionRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/InterestingCollectionRepository.java
@@ -4,6 +4,7 @@ import com.pintogether.backend.entity.InterestingCollection;
 import com.pintogether.backend.entity.enums.InterestType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InterestingCollectionRepository extends JpaRepository<InterestingCollection, Long> {
@@ -14,4 +15,9 @@ public interface InterestingCollectionRepository extends JpaRepository<Interesti
     boolean existsByMemberIdAndCollectionIdAndInterestType(Long memberId, Long collectionId, InterestType interestType);
 
     Optional<InterestingCollection> findOneByMemberIdAndCollectionIdAndInterestType(Long memberId, Long collectionId, InterestType interestType);
+
+    List<InterestingCollection> findAllByCollectionId(Long collectionId);
+
+    List<InterestingCollection> findAllByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/pintogether/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/NotificationRepository.java
@@ -2,9 +2,20 @@ package com.pintogether.backend.repository;
 
 import com.pintogether.backend.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     public List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
+
+    public List<Notification> findAllByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE Notification n SET n.subject = NULL WHERE n.subject.id = :id")
+    void updateSubjectToNull(@Param("id") Long subjectId);
 }

--- a/src/main/java/com/pintogether/backend/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/SearchHistoryRepository.java
@@ -6,10 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
 
     Page<SearchHistory> findByMemberIdOrderByIdDesc(Pageable pageable, Long memberId);
 
     Page<SearchHistory> findByMemberIdAndSearchTypeOrderByIdDesc(Pageable pageable, Long memberId, SearchType searchType);
+
+    List<SearchHistory> findAllByMemberId(Long memberId);
 
 }

--- a/src/main/java/com/pintogether/backend/repository/StarRepository.java
+++ b/src/main/java/com/pintogether/backend/repository/StarRepository.java
@@ -12,6 +12,6 @@ public interface StarRepository extends JpaRepository<Star, Long> {
 
     List<Star> findAllByMemberId(Long memberId);
 
-    Optional<Star> findByMemberId(Long MemberId);
+    List<Star> findAllByPlaceId(Long placeId);
 
 }

--- a/src/main/java/com/pintogether/backend/service/CollectionService.java
+++ b/src/main/java/com/pintogether/backend/service/CollectionService.java
@@ -3,10 +3,7 @@ package com.pintogether.backend.service;
 import com.pintogether.backend.dto.CreateCollectionCommentRequestDTO;
 import com.pintogether.backend.dto.CreateCollectionRequestDTO;
 import com.pintogether.backend.dto.UpdateCollectionRequestDTO;
-import com.pintogether.backend.entity.Collection;
-import com.pintogether.backend.entity.CollectionComment;
-import com.pintogether.backend.entity.CollectionTag;
-import com.pintogether.backend.entity.Pin;
+import com.pintogether.backend.entity.*;
 import com.pintogether.backend.entity.enums.InterestType;
 import com.pintogether.backend.exception.CustomException;
 import com.pintogether.backend.model.StatusCode;
@@ -59,6 +56,7 @@ public class CollectionService {
         if (!memberId.equals(collection.getMember().getId())) {
             throw new CustomException(StatusCode.FORBIDDEN, "컬렉션을 삭제할 권한이 없습니다.");
         }
+        interestingCollectionRepository.deleteAll(interestingCollectionRepository.findAllByCollectionId(collection.getId()));
         this.collectionRepository.delete(collection);
     }
     public Collection createCollection(Long memberId, CreateCollectionRequestDTO createCollectionRequestDTO) {

--- a/src/main/java/com/pintogether/backend/service/ComplaintService.java
+++ b/src/main/java/com/pintogether/backend/service/ComplaintService.java
@@ -2,6 +2,7 @@ package com.pintogether.backend.service;
 
 import com.pintogether.backend.dto.CreateComplaintRequestDTO;
 import com.pintogether.backend.dto.ShowComplaintResponseDTO;
+import com.pintogether.backend.entity.Collection;
 import com.pintogether.backend.entity.Complaint;
 import com.pintogether.backend.entity.Member;
 import com.pintogether.backend.repository.ComplaintRepository;

--- a/src/main/java/com/pintogether/backend/service/InterestingCollectionService.java
+++ b/src/main/java/com/pintogether/backend/service/InterestingCollectionService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -76,5 +78,9 @@ public class InterestingCollectionService {
             throw new CustomException(StatusCode.BAD_REQUEST, "스크랩하지 않은 컬렉션입니다.");
         }
         interestingCollectionRepository.delete(interestingCollection);
+    }
+
+    public void deleteInterestingCollectionByCollectionId(Long collectionId) {
+        interestingCollectionRepository.deleteAll(interestingCollectionRepository.findAllByCollectionId(collectionId));
     }
 }

--- a/src/main/java/com/pintogether/backend/service/MemberService.java
+++ b/src/main/java/com/pintogether/backend/service/MemberService.java
@@ -7,10 +7,7 @@ import com.pintogether.backend.entity.enums.RegistrationSource;
 import com.pintogether.backend.entity.enums.RoleType;
 import com.pintogether.backend.exception.CustomException;
 import com.pintogether.backend.model.StatusCode;
-import com.pintogether.backend.repository.CollectionRepository;
-import com.pintogether.backend.repository.FollowingRepository;
-import com.pintogether.backend.repository.InterestingCollectionRepository;
-import com.pintogether.backend.repository.MemberRepository;
+import com.pintogether.backend.repository.*;
 import com.pintogether.backend.util.RandomNicknameGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,6 +26,10 @@ public class MemberService {
     private final InterestingCollectionRepository interestingCollectionRepository;
     private final FollowingRepository followingRepository;
     private final AmazonS3Service amazonS3Service;
+    private final ComplaintRepository complaintRepository;
+    private final NotificationRepository notificationRepository;
+    private final StarRepository starRepository;
+    private final SearchHistoryRepository searchHistoryRepository;
     public Member getMember(Long id) {
         return memberRepository.findOneById(id).orElse(null);
     }
@@ -60,6 +61,15 @@ public class MemberService {
 
     public void delete(Long id) {
         Member foundMember = this.getMember(id);
+        interestingCollectionRepository.deleteAll(interestingCollectionRepository.findAllByMemberId(id));
+        followingRepository.deleteAll(followingRepository.findAllByFolloweeId(id));
+        followingRepository.deleteAll(followingRepository.findAllByFollowerId(id));
+        complaintRepository.updateReporterToNull(id);
+        complaintRepository.updateTargetMemberToNull(id);
+        notificationRepository.deleteAll(notificationRepository.findAllByMemberId(id));
+        notificationRepository.updateSubjectToNull(id);
+        starRepository.deleteAll(starRepository.findAllByMemberId(id));
+        searchHistoryRepository.deleteAll(searchHistoryRepository.findAllByMemberId(id));
         memberRepository.delete(foundMember);
     }
 

--- a/src/main/java/com/pintogether/backend/service/PlaceService.java
+++ b/src/main/java/com/pintogether/backend/service/PlaceService.java
@@ -49,4 +49,13 @@ public class PlaceService {
         return pinRepository.countByPlaceId(placeId);
     }
 
+    public void delete(Long id) {
+        Place foundPlace = placeRepository.findById(id).orElse(null);
+        starRepository.deleteAll(starRepository.findAllByPlaceId(id));
+        if (foundPlace != null) {
+            placeRepository.delete(foundPlace);
+        }
+
+    }
+
 }


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- Collection, CollectionComment, CollectionTag, Member, Pin, PinImage, PinTag, Place 엔티티에 소프트 삭제(Soft Delete) 기능을 적용했습니다.
- @OnDelete 애노테이션 사용 대신,  트랜잭션으로 묶는 방법으로 변경하였습니다.
   - 소프트 삭제가 적용된 엔티티를 단방향으로 참조하고 있는 모든 엔티티에 대해 @OnDelete를 사용하여 영속성 전이를 수행하고 있었는데요, 소프트 삭제 적용으로 인해 엔티티 삭제 쿼리 대신 업데이트 쿼리가 실행되면서 @OnDelete가 작동하지 않는 문제가 발생했습니다. 이를 해결하기 위해, 엔티티 삭제 메서드에 연관된 엔티티 삭제 로직을 추가하고, 이를 트랜잭션으로 묶는 방식으로 변경했습니다.
<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
