### PR TITLE
bug: soft-delete 생성 메서드에 entityStatus 속성 추가

### DIFF
--- a/src/main/java/com/pintogether/backend/auth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/pintogether/backend/auth/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.pintogether.backend.auth;
 
 import com.pintogether.backend.entity.Member;
+import com.pintogether.backend.entity.enums.EntityStatus;
 import com.pintogether.backend.entity.enums.RegistrationSource;
 import com.pintogether.backend.entity.enums.RoleType;
 import com.pintogether.backend.repository.MemberRepository;
@@ -83,7 +84,8 @@ public class OAuth2LoginSuccessHandler extends SavedRequestAwareAuthenticationSu
                     .roleType(RoleType.ROLE_MEMBER)
                     .bio("")
                     .avatar("https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/profile1.png")
-                    .membername(RandomMembernameGenerator.generate()+"$").build();
+                    .membername(RandomMembernameGenerator.generate()+"$")
+                    .entityStatus(EntityStatus.ACTIVE).build();
             memberRepository.save(newMember);
             newMember.setMembername(
                     newMember.getMembername() + newMember.getId());

--- a/src/main/java/com/pintogether/backend/entity/Collection.java
+++ b/src/main/java/com/pintogether/backend/entity/Collection.java
@@ -51,6 +51,7 @@ public class Collection extends BaseEntity {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private EntityStatus entityStatus;
 
     public void updateTitle(String title) {

--- a/src/main/java/com/pintogether/backend/entity/CollectionComment.java
+++ b/src/main/java/com/pintogether/backend/entity/CollectionComment.java
@@ -31,12 +31,14 @@ public class CollectionComment extends BaseEntity {
     private String contents;
 
     @Enumerated(EnumType.STRING)
-    private EntityStatus entityStatus = EntityStatus.ACTIVE;
+    @NotNull
+    private EntityStatus entityStatus;
 
-    CollectionComment(Collection collection, Member member, String contents) {
+    CollectionComment(Collection collection, Member member, String contents, EntityStatus entityStatus) {
         this.collection = collection;
         this.member = member;
         this.contents = contents;
+        this.entityStatus = entityStatus;
         this.collection.getCollectionComments().add(this);
     }
 }

--- a/src/main/java/com/pintogether/backend/entity/CollectionTag.java
+++ b/src/main/java/com/pintogether/backend/entity/CollectionTag.java
@@ -25,12 +25,14 @@ public class CollectionTag {
     private String tag;
 
     @Enumerated(EnumType.STRING)
-    private EntityStatus entityStatus = EntityStatus.ACTIVE;
+    @NotNull
+    private EntityStatus entityStatus;
 
     @Builder
-    public CollectionTag(Collection collection, String tag) {
+    public CollectionTag(Collection collection, String tag, EntityStatus entityStatus) {
         this.collection = collection;
         this.tag = tag;
+        this.entityStatus = entityStatus;
         this.collection.getCollectionTags().add(this);
     }
 }

--- a/src/main/java/com/pintogether/backend/entity/Member.java
+++ b/src/main/java/com/pintogether/backend/entity/Member.java
@@ -56,10 +56,10 @@ public class Member {
     private final List<Collection> collections = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
-    private EntityStatus entityStatus = EntityStatus.ACTIVE;
+    private EntityStatus entityStatus;
 
     @Builder
-    public Member(String name, String membername, String bio, String avatar, RegistrationSource registrationSource, String registrationId, RoleType roleType) {
+    public Member(String name, String membername, String bio, String avatar, RegistrationSource registrationSource, String registrationId, RoleType roleType, EntityStatus entityStatus) {
         this.name = name;
         this.membername = membername;
         this.avatar = avatar;
@@ -68,6 +68,7 @@ public class Member {
         this.registrationId = registrationId;
         this.roleType = roleType;
         this.alertCnt = 0;
+        this.entityStatus = entityStatus;
     }
 
     public void updateMember(final UpdateMemberRequestDTO updateMemberRequestDTO) {

--- a/src/main/java/com/pintogether/backend/entity/Pin.java
+++ b/src/main/java/com/pintogether/backend/entity/Pin.java
@@ -4,6 +4,7 @@ import com.pintogether.backend.dto.ShowPinResponseDTO;
 import com.pintogether.backend.entity.enums.EntityStatus;
 import com.pintogether.backend.util.DateConverter;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -39,7 +40,8 @@ public class Pin extends BaseEntity {
     private final List<PinImage> pinImages = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
-    private EntityStatus entityStatus = EntityStatus.ACTIVE;
+    @NotNull
+    private EntityStatus entityStatus;
     public void updateReview(String review) {
         this.review = review;
     }
@@ -65,12 +67,13 @@ public class Pin extends BaseEntity {
     public void deletePlace() { this.place = null; }
 
     @Builder
-    public Pin(Place place, Collection collection, String review, List<PinTag> pinTags, List<PinImage> pinImages) {
+    public Pin(Place place, Collection collection, String review, List<PinTag> pinTags, List<PinImage> pinImages, EntityStatus entityStatus) {
         this.place = place;
         this.collection = collection;
         this.review = review;
         this.pinTags.addAll(pinTags);
         this.pinImages.addAll(pinImages);
+        this.entityStatus = entityStatus;
     }
 
     public ShowPinResponseDTO toShowPinResponseDTO() {

--- a/src/main/java/com/pintogether/backend/entity/PinImage.java
+++ b/src/main/java/com/pintogether/backend/entity/PinImage.java
@@ -25,12 +25,14 @@ public class PinImage {
     private String imagePath;
 
     @Enumerated(EnumType.STRING)
-    private EntityStatus entityStatus = EntityStatus.ACTIVE;
+    @NotNull
+    private EntityStatus entityStatus;
 
     @Builder
-    public PinImage(Pin pin, String imagePath) {
+    public PinImage(Pin pin, String imagePath, EntityStatus entityStatus) {
         this.pin = pin;
         this.imagePath = imagePath;
+        this.entityStatus = entityStatus;
         this.pin.getPinImages().add(this);
     }
 }

--- a/src/main/java/com/pintogether/backend/entity/PinTag.java
+++ b/src/main/java/com/pintogether/backend/entity/PinTag.java
@@ -26,12 +26,14 @@ public class PinTag {
     private String tag;
 
     @Enumerated(EnumType.STRING)
-    private EntityStatus entityStatus = EntityStatus.ACTIVE;
+    @NotNull
+    private EntityStatus entityStatus;
 
     @Builder
-    public PinTag(Pin pin, String tag) {
+    public PinTag(Pin pin, String tag, EntityStatus entityStatus) {
         this.pin = pin;
         this.tag = tag;
+        this.entityStatus = entityStatus;
         this.pin.getPinTags().add(this);
     }
 }

--- a/src/main/java/com/pintogether/backend/service/CollectionService.java
+++ b/src/main/java/com/pintogether/backend/service/CollectionService.java
@@ -63,12 +63,14 @@ public class CollectionService {
                 .title(createCollectionRequestDTO.getTitle())
                 .thumbnail("https://pintogether-img.s3.ap-northeast-2.amazonaws.com/default/collection1.png")
                 .details(createCollectionRequestDTO.getDetails())
+                .entityStatus(EntityStatus.ACTIVE)
                 .build();
 
         List<CollectionTag> collectionTags = createCollectionRequestDTO.getTags().stream()
                 .map(tag -> CollectionTag.builder()
                         .collection(newCollection)
                         .tag(tag)
+                        .entityStatus(EntityStatus.ACTIVE)
                         .build())
                 .toList();
         collectionRepository.save(newCollection);
@@ -115,6 +117,7 @@ public class CollectionService {
                 .collection(collection)
                 .member(memberService.getMember(memberId))
                 .contents(createCollectionCommentRequestDTO.getContents())
+                .entityStatus(EntityStatus.ACTIVE)
                 .build();
         collectionCommentRepository.save(collectionComment);
     }

--- a/src/main/java/com/pintogether/backend/service/PinService.java
+++ b/src/main/java/com/pintogether/backend/service/PinService.java
@@ -2,6 +2,7 @@ package com.pintogether.backend.service;
 
 import com.pintogether.backend.dto.*;
 import com.pintogether.backend.entity.*;
+import com.pintogether.backend.entity.enums.EntityStatus;
 import com.pintogether.backend.exception.CustomException;
 import com.pintogether.backend.model.CustomStatusMessage;
 import com.pintogether.backend.model.StatusCode;
@@ -39,6 +40,7 @@ public class PinService {
                 .place(place)
                 .collection(collection)
                 .review(createPinRequestDTO.getReview())
+                .entityStatus(EntityStatus.ACTIVE)
                 .build();
         if (createPinRequestDTO.getTags() != null) {
             for (String x : createPinRequestDTO.getTags()) {
@@ -46,6 +48,7 @@ public class PinService {
                         PinTag.builder()
                                 .pin(pin)
                                 .tag(x)
+                                .entityStatus(EntityStatus.ACTIVE)
                                 .build());
             }
         }
@@ -55,6 +58,7 @@ public class PinService {
                         PinImage.builder()
                                 .pin(pin)
                                 .imagePath(x)
+                                .entityStatus(EntityStatus.ACTIVE)
                                 .build()
                 );
             }
@@ -101,12 +105,14 @@ public class PinService {
             pin.getPinTags().add(PinTag.builder()
                             .tag(x)
                             .pin(pin)
+                            .entityStatus(EntityStatus.ACTIVE)
                             .build());
         }
         for (String x : updatePinReqeustDTO.getImagePaths()) {
             pin.getPinImages().add(PinImage.builder()
                             .imagePath(x)
                             .pin(pin)
+                            .entityStatus(EntityStatus.ACTIVE)
                             .build());
         }
         pinRepository.save(pin);


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
-  soft-delete 적용된 엔티티 생성자들에 entityStatus필드 값도 추가하였습니다.
- 

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
