### PR TITLE
bug: 컬렉션 수정에 의한 태그 생성시 entityStatus 속성 추가

### DIFF
--- a/src/main/java/com/pintogether/backend/service/CollectionService.java
+++ b/src/main/java/com/pintogether/backend/service/CollectionService.java
@@ -94,6 +94,7 @@ public class CollectionService {
                 .map(tag -> CollectionTag.builder()
                         .collection(collection)
                         .tag(tag)
+                        .entityStatus(EntityStatus.ACTIVE)
                         .build())
                 .collect(Collectors.toList());
         collection.updateTitle(updateCollectionRequestDTO.getTitle());


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- CollectionService::update 에서 태그 생성시 entityStatus속성이 누락되어 notNull 오류가 발생하였습니다. entityStatus 속성을 추가하여 문제 해결하였습니다.
- 

<br/>

## 📝 주의 사항 & 리뷰 요청
- 
- 

<br/>

## ⚡️ Issue number & Link
-
- 

<br/>

## 📸 ScreenShot
-

<br/>
